### PR TITLE
Feature/darkmode

### DIFF
--- a/wishList.css
+++ b/wishList.css
@@ -192,3 +192,27 @@ input:checked + .slider:before {
     color: white;
 }
 
+.dark-mode .empty-wishList-container{
+    background-color: #444;
+}
+.dark-mode .wishList-page{
+    background-color: #444;
+
+}
+
+.dark-mode .return-to-shop {
+    background-color: grey;
+    border: #121212;
+    color: white;
+    padding: 10px 20px;
+    border: none;
+    cursor: pointer;
+    font-size: 16px;
+    border-radius: 4px;
+    margin-top: 10px;
+    transition: background-color 0.3s ease;
+}
+
+.return-to-shop:hover {
+    background-color: #fc8506da;
+}

--- a/wishList.css
+++ b/wishList.css
@@ -1,11 +1,11 @@
 /* Wishlist Page Styling */
 .wishList-page {
     max-width: 900px;
-    margin: 80px auto 20px; /* Added margin at the top */
+    margin: 80px auto 20px;
     padding: 20px;
-    background: white;
+    background: #fff;
     border-radius: 10px;
-    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.1);
+    box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.15);
 }
 
 /* Wishlist Items */
@@ -13,15 +13,23 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    border-bottom: 1px solid #ddd;
-    padding: 15px 0;
+    padding: 15px;
+    background: #f9f9f9;
+    border-radius: 8px;
+    margin-bottom: 15px;
+    transition: all 0.3s ease-in-out;
+}
+
+.wishlist-item:hover {
+    transform: scale(1.02);
+    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.20);
 }
 
 .wishlist-item img {
-    width: 80px;
-    height: 80px;
+    width: 100px;
+    height: 100px;
     object-fit: cover;
-    border-radius: 5px;
+    border-radius: 10px;
     margin-right: 15px;
 }
 
@@ -29,6 +37,7 @@
     display: flex;
     align-items: center;
     gap: 15px;
+    flex-grow: 1;
 }
 
 .product-wishlist div {
@@ -37,9 +46,10 @@
 }
 
 .product-wishlist p {
-    font-size: 18px;
-    font-weight: bold;
-    color: #333;
+    font-size: 20px;
+    font-weight: 600;
+    color: #222;
+    margin: 5px 0;
 }
 
 .product-wishlist small {
@@ -47,32 +57,66 @@
     font-size: 14px;
 }
 
-.product-wishlist a {
-    color: red;
-    text-decoration: none;
+/* Buttons */
+
+.remove-wishlist-btn {
+    padding: 10px 15px;
     font-size: 14px;
-    margin-top: 5px;
+    font-weight: bold;
+    border: none;
+    border-radius: 5px;
     cursor: pointer;
+    transition: all 0.3s ease-in-out;
+    
 }
 
-.product-wishlist a:hover {
-    text-decoration: underline;
-}
-
-
-
-.cart-btn{
-    margin: 0.5rem;
-    border-radius: 0.5rem;
-}
-
-/* Footer - Fixed at Bottom */
-/* footer {
-    position: fixed;
-    bottom: 0;
-    width: 100%;
-    background: black;
+.cart-btn {
+    background: #28a745;
     color: white;
-    padding: 15px 0;
-    text-align: center;
-} */
+    padding: 10px 15px;
+    font-size: 14px;
+    font-weight: bold;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: all 0.3s ease-in-out;
+}
+
+.cart-btn:hover {
+    background: #218838;
+}
+
+.remove-wishlist-btn {
+    background: #dc3545;
+    color: white;
+    margin-top: 0.5rem;
+}
+
+.remove-wishlist-btn:hover {
+    background: #c82333;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .wishlist-item {
+        flex-direction: column;
+        text-align: center;
+        padding: 20px;
+    }
+
+    .product-wishlist {
+        flex-direction: column;
+        align-items: center;
+        gap: 10px;
+    }
+
+    .wishlist-item img {
+        margin-bottom: 10px;
+    }
+
+    .cart-btn,
+    .remove-btn {
+        width: 100%;
+        margin-top: 5px;
+    }
+}

--- a/wishList.css
+++ b/wishList.css
@@ -120,3 +120,75 @@
         margin-top: 5px;
     }
 }
+
+
+/* darkmode button */
+
+/* Toggle Switch */
+.theme-switch {
+    position: relative;
+    display: inline-block;
+    width: 50px;
+    height: 24px;
+}
+
+.theme-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    border-radius: 34px;
+    transition: 0.4s;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 18px;
+    width: 18px;
+    left: 4px;
+    bottom: 3px;
+    background-color: white;
+    border-radius: 50%;
+    transition: 0.4s;
+}
+
+input:checked + .slider {
+    background-color: #222;
+}
+
+input:checked + .slider:before {
+    transform: translateX(26px);
+}
+
+
+
+/* Dark Mode Styles */
+.dark-mode {
+    background-color: #121212;
+    color: white;
+}
+
+.dark-mode .product-card {
+    background-color: #1e1e1e;
+    border: 1px solid #444;
+}
+
+.dark-mode .navbar {
+    background-color: #222;
+}
+
+.dark-mode button {
+    background-color: #444;
+    color: white;
+}
+

--- a/wishList.html
+++ b/wishList.html
@@ -26,6 +26,11 @@
               <li><h1><a href="Product.html">PRODUCTS</a></h1></li>
               <li><h1><a href="wishList.html">WISH LIST</a></h1></li>
               <li><h1><a href="contact.html">CONTACT US</a></h1></li>
+              <label class="theme-switch">
+                <input type="checkbox" id="darkModeToggle">
+                <span class="slider"></span>
+             </label>
+            
           </ul>
       </div>
       <div class="nav-icons">

--- a/wishList.js
+++ b/wishList.js
@@ -123,7 +123,6 @@ function loadWishListItems() {
     });
 }
 
-
 // Function to remove an item from the wishlist
 function removeFromWishList(productName) {
     wishList = wishList.filter(item => item.name !== productName);
@@ -138,3 +137,26 @@ function removeFromWishList(productName) {
 if (document.querySelector('.wishList-page')) {
     loadWishListItems();
 }
+
+/* 🚀 DARK MODE FUNCTIONALITY 🚀 */
+document.addEventListener("DOMContentLoaded", function () {
+    const darkModeToggle = document.getElementById("darkModeToggle");
+    const body = document.body;
+
+    // Check if dark mode is enabled in localStorage
+    if (localStorage.getItem("theme") === "dark") {
+        body.classList.add("dark-mode");
+        darkModeToggle.checked = true;
+    }
+
+    // Toggle dark mode on switch change
+    darkModeToggle.addEventListener("change", function () {
+        if (darkModeToggle.checked) {
+            body.classList.add("dark-mode");
+            localStorage.setItem("theme", "dark");
+        } else {
+            body.classList.remove("dark-mode");
+            localStorage.setItem("theme", "light");
+        }
+    });
+});


### PR DESCRIPTION
Summary
This pull request introduces a Dark Mode feature to enhance the user experience by allowing users to toggle between light and dark themes. The dark mode setting persists using localStorage, ensuring a seamless experience across sessions.
Issue: #86 

Changes Implemented
Added a Dark Mode button to toggle between light and dark themes.

Implemented a function to apply the selected theme on page load.

Utilized localStorage to store and retrieve the user's theme preference.

Updated CSS styles dynamically to ensure proper UI adjustments in dark mode.

How to Test
Click the Dark Mode button to switch between themes.

Refresh the page and confirm that the selected theme persists.

Verify that the wishlist functionality continues to work correctly in both themes.

Screenshots 
![Screenshot 2025-03-23 001724](https://github.com/user-attachments/assets/9abe19ee-529c-4f0a-a8f8-67bc2ab2a930)
![Screenshot 2025-03-23 001734](https://github.com/user-attachments/assets/3c67b8f1-7cca-4fbb-b10b-d5e7d8bb77b6)