### PR TITLE
changed section header color from primary to light

### DIFF
--- a/service.html
+++ b/service.html
@@ -283,7 +283,7 @@
         
         .section-header h2 {
             font-size: 36px;
-            color: var(--primary);
+            color: var(--light);
             margin-bottom: 15px;
             position: relative;
             display: inline-block;


### PR DESCRIPTION
This pull request includes a small change to the `service.html` file. The change modifies the color of the section header text from the primary color to a light color.

Related issue : #113 

Change in `service.html`:

* Modified the `.section-header h2` color from `var(--primary)` to `var(--light)` to adjust the visual appearance of the section headers.

### Screenshot
![image](https://github.com/user-attachments/assets/fd1aa996-ff96-4277-8411-6981b7fdfa60)
